### PR TITLE
사용자 인증, 사용자 정보

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 require("dotenv").config(); // .env 파일 로드
+const cookieParser = require('cookie-parser');
 
 const express = require("express");
 const compression = require("compression");
@@ -15,7 +16,12 @@ app.disable("x-powered-by");
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(methodOverride());
-app.use(cors());
+app.use(cookieParser());
+app.use(cors({
+    origin: 'http://localhost:5173', // ✅ 프론트 주소 (예: Vite)
+    credentials: true               // ✅ 쿠키 허용
+}));
+
 
 // Swagger 문서
 app.use("/api-docs", swaggerUI.serve, swaggerUI.setup(swaggerDocument, { explorer: true }));
@@ -32,4 +38,6 @@ app.use('/auth', authRouter);
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
     console.log(`🚀 Server running on http://localhost:${PORT}`);
+    console.log(`Swagger URL: http://localhost:${PORT}/api-docs`);
+    console.log(`http://localhost:3000/auth/google`)
 });

--- a/config/db.config.js
+++ b/config/db.config.js
@@ -1,0 +1,83 @@
+const {Pool} = require('pg')
+const pgp = require('pg-promise')()
+require("dotenv").config();
+
+class Database {
+    constructor() {
+        this.pool = new Pool({
+            user: process.env.DB_USER,
+            host: process.env.DB_HOST,
+            database: process.env.DB_NAME,
+            password: process.env.DB_PASS,
+            port: process.env.DB_PORT,
+            max: 30,
+            idleTimeoutMillis: 10000,
+            connectionTimeoutMillis: 60000
+        });
+    }
+
+    /**
+     * Get a client connection from the pool.
+     */
+    async connect() {
+        try {
+            const client = await this.pool.connect();
+            return client;
+        } catch (error) {
+            console.error("Database connection error:", error);
+            throw error;
+        }
+    }
+
+    async query(query, params) {
+        try {
+            if (params) return await this.pool.query(query, params).then((dbRes) => {
+                return dbRes
+            })
+            return await this.pool.query(query).then((dbRes => {
+                return dbRes
+            }))
+        } catch (error) {
+            console.log('QUERY Error:', error)
+            throw error
+        }
+    }
+
+    async begin(client) {
+        if (!this.pool) {
+            console.log("no pool")
+            throw new Error('this.pool is undefined. Ensure the pool is properly initialized.');
+        }
+        try {
+            await client.query('BEGIN');
+        } catch (error) {
+            console.error('Transaction BEGIN Error:', error);
+            throw error;
+        }
+    }
+
+
+    async commit(client) {
+        try {
+            await client.query('COMMIT');
+        } catch (error) {
+            console.error('Transaction COMMIT Error:', error);
+            throw error;
+        }
+    }
+
+    async rollback(client) {
+        try {
+            await client.query('ROLLBACK');
+        } catch (error) {
+            console.error('Transaction ROLLBACK Error:', error);
+            throw error;
+        }
+    }
+
+    async end() {
+        await this.pool.end()
+    }
+}
+
+module.exports = Database

--- a/config/swagger.json
+++ b/config/swagger.json
@@ -10,13 +10,134 @@
       "url": "http://localhost:3000"
     }
   ],
+  "components": {
+    "securitySchemes": {
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "refreshToken"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
   "paths": {
-    "/api/v1/login": {
-      "post": {
-        "summary": "User login",
+    "/auth/google": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "구글 로그인 요청",
+        "description": "Google OAuth 로그인 URL로 리디렉션, 사용자를 구글 로그인 창으로 이동시킴",
+        "responses": {
+          "302": {
+            "description": "구글 로그인 페이지로 리디렉션"
+          }
+        }
+      }
+    },
+    "/auth/google/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "로그인 완료 후 사용자 정보 수신",
+        "description": "구글이 authorization code를 보내주면, 이를 기반으로 사용자 정보를 받아옴",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "구글에서 전달받은 Authorization Code"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Successful login"
+            "description": "로그인 성공 메시지"
+          },
+          "500": {
+            "description": "구글 로그인 실패"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "로그아웃",
+        "description": "refreshToken 쿠키 삭제. 서버에서 로그아웃 처리",
+        "responses": {
+          "200": {
+            "description": "로그아웃 완료"
+          }
+        }
+      }
+    },
+    "/auth/token": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "accessToken 재발급",
+        "description": "쿠키에 저장된 refreshToken을 사용해 accessToken을 재발급합니다.",
+        "security": [{ "cookieAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "accessToken 재발급 성공",
+            "content": {
+              "application/json": {
+                "example": {
+                  "accessToken": "ya29.a0ARrdaM...",
+                  "expiresIn": 3599
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "refreshToken 쿠키 없음"
+          },
+          "500": {
+            "description": "accessToken 재발급 실패"
+          }
+        }
+      }
+    },
+    "/auth/me": {
+      "get": {
+        "tags": ["Auth"],
+        "summary": "내 정보 조회 (실시간 Google API)",
+        "description": "accessToken을 Authorization 헤더로 전달하면, Google OAuth 사용자 정보를 실시간 조회합니다.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Google 사용자 정보",
+            "content": {
+              "application/json": {
+                "example": {
+                  "email": "suyeun0109@gmail.com",
+                  "name": "조수연",
+                  "picture": "https://lh3.googleusercontent.com/...",
+                  "sub": "10394834728473498734",
+                  "email_verified": true,
+                  "locale": "ko"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "accessToken 누락 또는 유효하지 않음"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,16 @@
     "nodemon": "^3.1.10"
   },
   "dependencies": {
+    "axios": "^1.9.0",
     "compression": "^1.8.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "method-override": "^3.0.0",
+    "pg": "^8.16.0",
+    "pg-promise": "^11.13.0",
     "swagger-ui-express": "^5.0.1"
   }
 }

--- a/src/auth/auth.controller.js
+++ b/src/auth/auth.controller.js
@@ -1,0 +1,74 @@
+const { getGoogleAuthURL, getGoogleUserInfo, getNewAccessTokenFromGoogle, fetchUserInfoFromGoogle } = require('./auth.service');
+const { updateUserStatus } = require('./auth.repository')
+exports.googleLogin = (req, res) => {
+    const url = getGoogleAuthURL();
+    return res.redirect(url);
+};
+
+exports.googleCallback = async (req, res) => {
+    const code = req.query.code;
+    try {
+        const { accessToken, refreshToken,expiresIn, user } = await getGoogleUserInfo(code);
+
+        res.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            maxAge: 7 * 24 * 60 * 60 * 1000,
+        });
+
+        return res.json({
+            message: `환영합니다, ${user.name}님!`,
+            accessToken,
+            expiresIn,
+            user,
+        });
+    } catch (err) {
+        console.error('구글 로그인 실패:', err.message);
+        return res.status(500).send('로그인 실패');
+    }
+};
+
+//accessToken 만료 시 → 구글에게 재발급 요청
+exports.refreshGoogleAccessToken = async (req, res) => {
+    const refreshToken = req.cookies.refreshToken;
+
+    if (!refreshToken) {
+        return res.status(401).json({ message: 'Refresh Token이 없습니다.' });
+    }
+
+    try {
+        const { accessToken, expiresIn } = await getNewAccessTokenFromGoogle(refreshToken);
+        return res.json({ accessToken, expiresIn });
+    } catch (err) {
+        return res.status(500).json({ message: err.message || 'accessToken 재발급 실패' });
+    }
+};
+
+exports.logout = async (req, res) => {
+    const email = req.cookies.userEmail;
+
+    if (email) {
+        await updateUserStatus(email, 'OFFLINE');
+    }
+    res.clearCookie('refreshToken');
+    res.clearCookie('userEmail');
+    return res.status(200).json({message: '로그아웃 완료'});
+};
+
+exports.getGoogleProfile = async (req, res) => {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ message: 'Access Token이 없습니다.' });
+    }
+
+    const accessToken = authHeader.split(' ')[1];
+
+    try {
+        const user = await fetchUserInfoFromGoogle(accessToken);
+        return res.json(user);
+    } catch (err) {
+        return res.status(401).json({ message: '유효하지 않은 accessToken입니다.' });
+    }
+};

--- a/src/auth/auth.controller.js
+++ b/src/auth/auth.controller.js
@@ -1,74 +1,49 @@
-const { getGoogleAuthURL, getGoogleUserInfo, getNewAccessTokenFromGoogle, fetchUserInfoFromGoogle } = require('./auth.service');
-const { updateUserStatus } = require('./auth.repository')
+const {
+    getGoogleAuthURL,
+    handleGoogleCallback,
+    getNewAccessTokenFromGoogle,
+    handleLogout,
+    fetchUserInfoFromGoogle,
+} = require('./auth.service');
+
+// [1] 구글 로그인 URL 생성 → 리디렉션
 exports.googleLogin = (req, res) => {
     const url = getGoogleAuthURL();
     return res.redirect(url);
 };
 
+// [2] 구글 로그인 콜백 처리
 exports.googleCallback = async (req, res) => {
     const code = req.query.code;
-    try {
-        const { accessToken, refreshToken,expiresIn, user } = await getGoogleUserInfo(code);
-
-        res.cookie('refreshToken', refreshToken, {
+    const result = await handleGoogleCallback(code);
+    return res
+        .cookie('refreshToken', result.refreshToken, {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
             sameSite: 'strict',
             maxAge: 7 * 24 * 60 * 60 * 1000,
-        });
-
-        return res.json({
-            message: `환영합니다, ${user.name}님!`,
-            accessToken,
-            expiresIn,
-            user,
-        });
-    } catch (err) {
-        console.error('구글 로그인 실패:', err.message);
-        return res.status(500).send('로그인 실패');
-    }
+        })
+        .json(result.response);
 };
 
-//accessToken 만료 시 → 구글에게 재발급 요청
+// [3] accessToken 재발급
 exports.refreshGoogleAccessToken = async (req, res) => {
-    const refreshToken = req.cookies.refreshToken;
-
-    if (!refreshToken) {
-        return res.status(401).json({ message: 'Refresh Token이 없습니다.' });
-    }
-
-    try {
-        const { accessToken, expiresIn } = await getNewAccessTokenFromGoogle(refreshToken);
-        return res.json({ accessToken, expiresIn });
-    } catch (err) {
-        return res.status(500).json({ message: err.message || 'accessToken 재발급 실패' });
-    }
+    const result = await getNewAccessTokenFromGoogle(req.cookies.refreshToken);
+    return res.status(result.status).json(result.body);
 };
 
+// [4] 로그아웃 처리
 exports.logout = async (req, res) => {
-    const email = req.cookies.userEmail;
-
-    if (email) {
-        await updateUserStatus(email, 'OFFLINE');
-    }
+    const result = await handleLogout(req.cookies.userEmail);
     res.clearCookie('refreshToken');
     res.clearCookie('userEmail');
-    return res.status(200).json({message: '로그아웃 완료'});
+    return res.status(result.status).json({ message: result.message });
 };
 
+// [5] accessToken으로 사용자 정보 조회
 exports.getGoogleProfile = async (req, res) => {
     const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        return res.status(401).json({ message: 'Access Token이 없습니다.' });
-    }
-
-    const accessToken = authHeader.split(' ')[1];
-
-    try {
-        const user = await fetchUserInfoFromGoogle(accessToken);
-        return res.json(user);
-    } catch (err) {
-        return res.status(401).json({ message: '유효하지 않은 accessToken입니다.' });
-    }
+    const token = authHeader?.split(' ')[1];
+    const result = await fetchUserInfoFromGoogle(token);
+    return res.status(result.status).json(result.body);
 };

--- a/src/auth/auth.repository.js
+++ b/src/auth/auth.repository.js
@@ -22,3 +22,23 @@ exports.updateUserStatus = async (email, status) => {
         [status, email]
     );
 };
+
+//  refresh token으로 사용자 조회
+exports.findByRefreshToken = async (refreshToken) => {
+    const query = 'SELECT * FROM users WHERE refresh_token = $1 LIMIT 1';
+    const result = await db.query(query, [refreshToken]);
+    return result.rows[0] || null;
+};
+
+//  refresh token 저장
+exports.updateRefreshToken = async (userId, refreshToken) => {
+    const query = 'UPDATE users SET refresh_token = $1 WHERE id = $2';
+    await db.query(query, [refreshToken, userId]);
+};
+
+
+//  refresh token 제거 (로그아웃)
+exports.clearRefreshToken = async (userId) => {
+    const query = 'UPDATE users SET refresh_token = NULL WHERE id = $1';
+    await db.query(query, [userId]);
+};

--- a/src/auth/auth.repository.js
+++ b/src/auth/auth.repository.js
@@ -1,0 +1,24 @@
+const Database = require('../../config/db.config');
+const db = new Database();
+
+exports.findUserByEmail = async (email) => {
+    const query = 'SELECT * FROM users WHERE email = $1 LIMIT 1';
+    const result = await db.query(query, [email]);
+    return result.rows[0] || null;
+};
+
+exports.createUser = async ({ email, name, login_provider }) => {
+    const query = `
+    INSERT INTO users (email, name, login_provider)
+    VALUES ($1, $2, $3)
+    RETURNING *`;
+    const result = await db.query(query, [email, name, login_provider]);
+    return result.rows[0];
+};
+
+exports.updateUserStatus = async (email, status) => {
+    await db.query(
+        'UPDATE users SET status = $1 WHERE email = $2',
+        [status, email]
+    );
+};

--- a/src/auth/auth.router.js
+++ b/src/auth/auth.router.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { googleLogin, googleCallback, refreshGoogleAccessToken,logout, getGoogleProfile } = require('./auth.controller');
+
+router.get('/google', googleLogin);
+router.get('/google/callback', googleCallback);
+router.post('/token', refreshGoogleAccessToken);
+router.post('/logout', logout);
+router.get('/me', getGoogleProfile);
+
+module.exports = router;

--- a/src/auth/auth.service.js
+++ b/src/auth/auth.service.js
@@ -1,9 +1,7 @@
 const axios = require('axios');
-const jwt = require('jsonwebtoken');
-const { findUserByEmail, createUser, updateUserStatus } = require('./auth.repository');
+const { findUserByEmail, createUser, updateUserStatus, updateRefreshToken, clearRefreshToken } = require('./auth.repository');
 require('dotenv').config();
 
-// [1] 구글 로그인 URL 생성
 exports.getGoogleAuthURL = () => {
     const rootUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
     const options = new URLSearchParams({
@@ -17,50 +15,57 @@ exports.getGoogleAuthURL = () => {
     return `${rootUrl}?${options.toString()}`;
 };
 
-// [2] 구글로부터 access_token + refresh_token 받기
-exports.getGoogleUserInfo = async (code) => {
-    // (1) access token 요청
-    const tokenRes = await axios.post('https://oauth2.googleapis.com/token', null, {
-        params: {
-            code,
-            client_id: process.env.GOOGLE_CLIENT_ID,
-            client_secret: process.env.GOOGLE_CLIENT_SECRET,
-            redirect_uri: process.env.GOOGLE_REDIRECT_URI,
-            grant_type: 'authorization_code',
-        },
-    });
-
-    const { access_token, refresh_token, expires_in } = tokenRes.data;
-    const accessToken = access_token;
-    const refreshToken = refresh_token;
-    const expiresIn = expires_in;
-
-    // (2) access token으로 사용자 정보 조회
-    const userInfoRes = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
-        headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    const { email, name, picture } = userInfoRes.data;
-
-    // (3) DB에 사용자 저장 (있으면 패스, 없으면 create)
-    let user = await findUserByEmail(email);
-    if (!user) {
-        user = await createUser({
-            email,
-            name,
-            login_provider: 'google',
+exports.handleGoogleCallback = async (code) => {
+    try {
+        // 1. 토큰 요청
+        const tokenRes = await axios.post('https://oauth2.googleapis.com/token', null, {
+            params: {
+                code,
+                client_id: process.env.GOOGLE_CLIENT_ID,
+                client_secret: process.env.GOOGLE_CLIENT_SECRET,
+                redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+                grant_type: 'authorization_code',
+            },
         });
-    }
-    await updateUserStatus(email, 'ONLINE');
 
-    return {
-        accessToken,
-        refreshToken,
-        expiresIn,
-        user: { email, name, picture },
-    };
+        const { access_token, refresh_token, expires_in } = tokenRes.data;
+
+        // 2. 유저 정보 요청
+        const userInfoRes = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
+            headers: { Authorization: `Bearer ${access_token}` },
+        });
+        const { email, name, picture } = userInfoRes.data;
+
+        // 3. 유저 DB 처리
+        let user = await findUserByEmail(email);
+        if (!user) {
+            user = await createUser({ email, name, login_provider: 'google' });
+        }
+        await updateUserStatus(email, 'ONLINE');
+        if (refresh_token) {
+            await updateRefreshToken(user.id, refresh_token);
+        }
+
+        return {
+            refreshToken: refresh_token,
+            response: {
+                message: `환영합니다, ${name}님`,
+                accessToken: access_token,
+                expiresIn: expires_in,
+                user: { email, name, picture },
+            },
+        };
+    } catch (err) {
+        console.error('구글 로그인 실패:', err.message);
+        throw new Error('로그인 실패');
+    }
 };
 
 exports.getNewAccessTokenFromGoogle = async (refreshToken) => {
+    if (!refreshToken) {
+        return { status: 401, body: { message: 'Refresh Token이 없습니다.' } };
+    }
+
     try {
         const res = await axios.post('https://oauth2.googleapis.com/token', null, {
             params: {
@@ -71,21 +76,47 @@ exports.getNewAccessTokenFromGoogle = async (refreshToken) => {
             },
         });
 
-        const { access_token, expires_in } = res.data;
-
-        return { accessToken: access_token, expiresIn: expires_in };
-    } catch (error) {
-        console.error('[Google Refresh Error]', error.message);
-        throw new Error('구글 accessToken 재발급 실패');
+        return {
+            status: 200,
+            body: {
+                accessToken: res.data.access_token,
+                expiresIn: res.data.expires_in,
+            },
+        };
+    } catch (err) {
+        return {
+            status: 500,
+            body: { message: err.message || 'accessToken 재발급 실패' },
+        };
     }
 };
 
-exports.fetchUserInfoFromGoogle = async (accessToken) => {
-    const res = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-    });
+exports.handleLogout = async (email) => {
+    if (!email) {
+        return { status: 400, message: '유저 이메일이 없습니다.' };
+    }
 
-    return res.data;
+    const user = await findUserByEmail(email);
+    if (user) {
+        await updateUserStatus(email, 'OFFLINE');
+        await clearRefreshToken(user.id);
+    }
+
+    return { status: 200, message: '로그아웃 완료' };
+};
+
+exports.fetchUserInfoFromGoogle = async (accessToken) => {
+    if (!accessToken) {
+        return { status: 401, body: { message: 'Access Token이 없습니다.' } };
+    }
+
+    try {
+        const res = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        return { status: 200, body: res.data };
+    } catch (err) {
+        return { status: 401, body: { message: '유효하지 않은 accessToken입니다.' } };
+    }
 };

--- a/src/auth/auth.service.js
+++ b/src/auth/auth.service.js
@@ -1,0 +1,91 @@
+const axios = require('axios');
+const jwt = require('jsonwebtoken');
+const { findUserByEmail, createUser, updateUserStatus } = require('./auth.repository');
+require('dotenv').config();
+
+// [1] 구글 로그인 URL 생성
+exports.getGoogleAuthURL = () => {
+    const rootUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
+    const options = new URLSearchParams({
+        redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+        client_id: process.env.GOOGLE_CLIENT_ID,
+        access_type: 'offline',
+        response_type: 'code',
+        prompt: 'consent',
+        scope: 'openid email profile',
+    });
+    return `${rootUrl}?${options.toString()}`;
+};
+
+// [2] 구글로부터 access_token + refresh_token 받기
+exports.getGoogleUserInfo = async (code) => {
+    // (1) access token 요청
+    const tokenRes = await axios.post('https://oauth2.googleapis.com/token', null, {
+        params: {
+            code,
+            client_id: process.env.GOOGLE_CLIENT_ID,
+            client_secret: process.env.GOOGLE_CLIENT_SECRET,
+            redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+            grant_type: 'authorization_code',
+        },
+    });
+
+    const { access_token, refresh_token, expires_in } = tokenRes.data;
+    const accessToken = access_token;
+    const refreshToken = refresh_token;
+    const expiresIn = expires_in;
+
+    // (2) access token으로 사용자 정보 조회
+    const userInfoRes = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const { email, name, picture } = userInfoRes.data;
+
+    // (3) DB에 사용자 저장 (있으면 패스, 없으면 create)
+    let user = await findUserByEmail(email);
+    if (!user) {
+        user = await createUser({
+            email,
+            name,
+            login_provider: 'google',
+        });
+    }
+    await updateUserStatus(email, 'ONLINE');
+
+    return {
+        accessToken,
+        refreshToken,
+        expiresIn,
+        user: { email, name, picture },
+    };
+};
+
+exports.getNewAccessTokenFromGoogle = async (refreshToken) => {
+    try {
+        const res = await axios.post('https://oauth2.googleapis.com/token', null, {
+            params: {
+                client_id: process.env.GOOGLE_CLIENT_ID,
+                client_secret: process.env.GOOGLE_CLIENT_SECRET,
+                refresh_token: refreshToken,
+                grant_type: 'refresh_token',
+            },
+        });
+
+        const { access_token, expires_in } = res.data;
+
+        return { accessToken: access_token, expiresIn: expires_in };
+    } catch (error) {
+        console.error('[Google Refresh Error]', error.message);
+        throw new Error('구글 accessToken 재발급 실패');
+    }
+};
+
+exports.fetchUserInfoFromGoogle = async (accessToken) => {
+    const res = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    return res.data;
+};


### PR DESCRIPTION
**1. 구글 로그인 요청**
**Endpoint:** GET /auth/google
**설명:** 
Google OAuth 2.0을 기반으로 로그인 인증을 시작하는 API입니다. 사용자가 이 엔드포인트에 접근하면 Google 로그인 페이지로 리디렉션됩니다.
**동작:** 
클라이언트가 이 URL로 이동하면 Google 로그인 창이 열립니다.
사용자 인증 후, Google은 로그인 결과를 콜백 URL(/auth/google/callback)로 전달합니다.

**2. 구글 로그인 콜백 처리**
**Endpoint:** GET /auth/google/callback
**설명:**
Google 인증 성공 후 호출되는 콜백 URL입니다. 이 API는 Google로부터 받은 사용자 정보를 바탕으로 토큰을 발급합니다.
**동작:**
최초 로그인인 경우 회원가입 처리를 진행합니다.
이미 가입된 사용자라면 바로 로그인 처리를 수행합니다.
Access Token과 Refresh Token을 발급하여 응답으로 반환하거나, 쿠키에 저장합니다.

**3. Access Token 재발급 (Refresh Token 사용)**
**Endpoint:** POST /auth/token
**설명:**
만료된 Access Token을 재발급하기 위한 API입니다. 사용자는 Refresh Token을 포함하여 요청하고, 유효한 경우 새로운 Access Token을 발급받습니다.
**요구사항:**
요청 시 Cookie 또는 Authorization 헤더에 유효한 Refresh Token이 포함되어야 합니다.
Refresh Token이 유효하지 않으면 401 Unauthorized를 반환합니다.
**응답:**
새롭게 발급된 Access Token (예: JSON 또는 Cookie)

**4. 로그아웃 (Refresh Token 삭제)**
**Endpoint:** POST /auth/logout
**설명:**
현재 로그인된 사용자의 Refresh Token을 서버에서 제거하여 로그아웃 처리합니다.
**동작:**
서버의 Redis 또는 DB에서 해당 Refresh Token을 삭제하거나 무효화합니다.
클라이언트 측에서도 Refresh Token 쿠키를 제거하도록 응답합니다.

**5. 내 정보 조회 (accessToken 필요)**
**Endpoint:** GET /auth/me
**설명:**
로그인된 사용자의 정보를 조회하는 API입니다. 요청 시 유효한 Access Token이 필요합니다.
**동작:**
Access Token이 Authorization: Bearer <token> 형식으로 헤더에 포함되어야 합니다.
토큰 검증 후, 해당 사용자 정보 (예: 이름, 이메일, 생성일 등)를 응답으로 반환합니다.
인증 실패 시 401 Unauthorized 반환