### PR TITLE
홈 리퀘스트 수정

### DIFF
--- a/src/a2a/a2a_router.py
+++ b/src/a2a/a2a_router.py
@@ -232,7 +232,9 @@ async def get_a2a_session(
             "rescheduleRequestedAt": place_pref.get("rescheduleRequestedAt"),  # [NEW] 재조율 요청 시간
             "rescheduleReason": place_pref.get("rescheduleReason"),
             # 나간 참여자 정보 (거절한 사람들)
-            "left_participants": place_pref.get("left_participants", [])
+            "left_participants": place_pref.get("left_participants", []),
+            # [NEW] 다박 일정 정보 - 1박 이상이면 시간 대신 날짜 범위 표시
+            "duration_nights": place_pref.get("duration_nights", 0)
         }
         
         # [PERFORMANCE] 캘린더 충돌 확인 비활성화 - Google Calendar API 호출이 ~1초 소요됨
@@ -766,7 +768,9 @@ async def get_user_sessions(
                 "process": process,
                 "has_conflict": has_conflict,
                 "conflicting_sessions": conflicting_sessions,
-                "left_participants": left_participants  # 프론트엔드 필터링용
+                "left_participants": left_participants,  # 프론트엔드 필터링용
+                # [NEW] 다박 일정 정보 - 1박 이상이면 시간 대신 날짜 범위 표시
+                "duration_nights": place_pref.get("duration_nights", 0)
             }
 
             session["title"] = title


### PR DESCRIPTION
- 리퀘스트 요청보내기 버튼 누르면 그 다음 요청을 보냈습니다! 화면까지 너무 오래걸려서 중간에 뭐 보내는 중입니다. 이거 뜨게 
- 리퀘스트에서 중복 요청 온 시간대면 알림 뜨게 하고 싶은데 or 중복 위험 있으면 아예 추천 일정에 안뜨게. → 일단 참고
- 리퀘스트 친구 선택시 글씨체 chat화면이랑 다름
- request 위 삭제
- 홈 상단 조이너 추가
- 1박 2박  a2a 뜨는거 해결
- request 칸 간격 붙이기